### PR TITLE
Changes to cli environmental variables.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "files.associations": {
+        "*.ejs": "html",
         "array": "cpp",
         "*.tcc": "cpp",
         "cctype": "cpp",
@@ -30,6 +31,7 @@
         "system_error": "cpp",
         "type_traits": "cpp",
         "typeinfo": "cpp",
-        "utility": "cpp"
+        "utility": "cpp",
+        "xstring": "cpp"
     }
 }

--- a/WakaTimeForUE4.uplugin
+++ b/WakaTimeForUE4.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.2.0",
+	"VersionName": "1.2.1",
 	"FriendlyName": "WakaTimeForUE4",
 	"Description": "WakaTime plugin for UE4. In development now.",
 	"Category": "Other",


### PR DESCRIPTION
Changed %homedrive%%homepath% to %userprofile%. The original can point unmapped drives and can cause errors especially on user accounts that do not have permissions (like at my job :))

Removed Intermediate Folder to match default cli usage. All other plugins use .wakatime folder directly just removed the nested folder.

Changed \ wakatime-cli.exe to + GWakaCliVersion to match exe file. Plugin searches for  wakatime-cli.exe but can find different cli's for different platforms. The Cliversion is already set as Global variable so this can be used.